### PR TITLE
Check Device Type before creating a new Accessory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "MOTION Blinds",
   "name": "@emotuzas/homebridge-motionblinds",
-  "version": "2.0.2",
+  "version": "2.1.3",
   "description": "Homebridge plugin to control MOTION Blinds by Coulisse B.V. including derivative products such as OmniaBlinds.",
   "license": "MIT",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -7,7 +7,7 @@ import type {
   Service,
   Characteristic,
 } from 'homebridge'
-import { DeviceStatus, DeviceType, DEVICE_TYPES, MotionGateway, Report } from 'motionblinds'
+import { DeviceStatus, DeviceType, DEVICE_TYPES, MotionGateway, Report, DEVICE_TYPE_BLIND } from 'motionblinds'
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings'
 import { MotionBlindsAccessory } from './platformAccessory'
@@ -110,6 +110,11 @@ export class MotionBlindsPlatform implements DynamicPlatformPlugin {
 
     const uuid = this.api.hap.uuid.generate(mac)
     const existingAccessory = this.accessories.find((accessory) => accessory.UUID === uuid)
+
+    if (deviceType !== DEVICE_TYPE_BLIND) {
+      this.log.debug(`Received device other than blind (${deviceType}), not adding it.`)
+      return
+    }
 
     if (existingAccessory) {
       // the accessory already exists


### PR DESCRIPTION
Motionblind's readAll function exposes all kind of devices. Among others, the gateway, which can not be controlled (at least not as a blind).